### PR TITLE
Issue #14 - Firefox search override

### DIFF
--- a/js/view/event.js
+++ b/js/view/event.js
@@ -73,12 +73,13 @@ function create_VIM_EVENTLISTENER(interpret, environment, messager, isActiveCont
   }
 
   function stopImmediatePropagation(event) {
+    event.preventDefault();
     event.stopImmediatePropagation();
   }
-  
+
   $(function() {
     bindBasicCommandModeKeys();
     bindSpecial();
     bindMouse();
   });
-} 
+}


### PR DESCRIPTION
This fixes the error with the Firefox browser page search and testing yielded no errors for me, but it may have interfered in other areas I did not perceive. `stopImmediatePropogation()` will not prevent any browser level functionality therefore I needed to use `preventDefault()`
