### PR TITLE
[Fix] Deleting the last word using `dw`

### DIFF
--- a/js/commands/timescommands.js
+++ b/js/commands/timescommands.js
@@ -99,24 +99,13 @@ function create_VIM_TIMESCOMMANDS(environment, messager) {
       return new_movement(from, to);
     } else if(movement === 'w') {
       var to = exe.moveToStartOfNextWord(obj, times);
-
-      if(to.lastPossible !== undefined) {
-        // because lastPossible is defined, we couldn't reach the next word
-        var inclusiveAtEnd = true;
-        var toObj = to.lastPossible;
-      } else {
-        var inclusiveAtEnd = false;
-        var toObj = to;
-      }
-
-      return new_movement(obj, toObj, true, inclusiveAtEnd);
+      return new_movement(obj, to, true, !!to.hitLastPossible);
     } else if(movement === 'e') {
       var to = exe.moveToEndOfWord(obj, times);
       return new_movement(obj, to);
     } else if(movement === 'b') {
-      var from = exe.moveLeft(obj);
       var to = exe.moveToStartOfWord(obj, times);
-      return new_movement(from, to);
+      return new_movement(obj, to, false, true);
     } else {
       return empty_movement;
       //return obj;

--- a/js/engine/executor.js
+++ b/js/engine/executor.js
@@ -397,7 +397,7 @@ function create_VIM_EXECUTOR(doc, context) {
     var fromStartOfALine = from.is(moveToStartOfLine(fromLine));
     var toEndOfALine = to.is(moveToEndOfLine(toLine));
     // deleting must be delayed, since affects each
-    var to_be_removed = [from];
+    var to_be_removed = [];
 
     chars().each(function(index) {
       if(isBetween(index, fromIndex, toIndex, inclusiveFrom, inclusiveTo)) {
@@ -670,6 +670,7 @@ function create_VIM_EXECUTOR(doc, context) {
         obj = first(next.find(S.character));
       else {
         obj = last(word(obj).find(S.character));
+        obj.hitLastPossible = true;
         break;
       }
     }


### PR DESCRIPTION
Artifact :
- After the operation, the cursor goes to start of the line.
- Instead, it should move left by one character. Solution :
- The position of the cursor after the operation. should depend on the nature of the motion (characterwise/linewise)
- This will need a refactor, we keep it for a later time.
- Maybe add this as a task in the tasks.txt file.